### PR TITLE
Move test dependencies to Makefile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 #  - docker pull rocker/r-base
 
 script:
-  - sudo PYTHONPATH=lib/ /usr/local/bin/py.test test/
+  - sudo make test
   - sudo sh -c "mkdir -p /etc/chains/devices; wget https://raw.githubusercontent.com/ChainsAutomation/chains/master/misc/examples/etc-master/chains.conf -O /etc/chains/chains.conf"
   - bin/dockerfile-assemble.py master
   - docker version

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ install:
 before_script:
   - "sekexe/run 'mount -t tmpfs -o size=8g tmpfs /var/lib/docker && docker -d -H tcp://0.0.0.0:2375' &"
   - "while ! docker info &> /dev/null ; do sleep 1; done"
-#  - docker pull rocker/r-base
 
 script:
   - sudo make test
@@ -31,7 +30,7 @@ script:
   - bin/dockerfile-assemble.py master
   - docker version
   - docker build --no-cache -t chains/chains-master .
-  - docker run -d --privileged --net=host chains/chains-master
+  - docker run -d chains/chains-master
   - docker ps
   - sleep 60
   - DOCKERID=`docker ps -q`; docker exec $DOCKERID /usr/bin/supervisorctl status

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ before_install:
 
 install:
   - sudo apt-get -qqy update
-  - sudo apt-get -qqy install lxc lxc-docker-1.6.0 slirp python-pip
-  - sudo /usr/bin/pip install pytest
+  - sudo apt-get -qqy install lxc lxc-docker-1.6.0 slirp
   - sudo sudo usermod -aG docker "$USER"
   - git clone git://github.com/cptactionhank/sekexe
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,13 @@
 .PHONY: test
 
-test:
-	PYTHONPATH=lib/ /usr/local/bin/py.test test/	
+deps:
+	set +e
+	apt-get install -y python-amqplib
+	ec=$?
+	set -e
+	if [ $ec -ne 0 ]; then
+	    easy_install amqplib
+	fi
+
+test: deps
+	PYTHONPATH=lib/ /usr/local/bin/py.test test/

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,9 @@
 .PHONY: test
 
 deps:
-	set +e
-	apt-get install -y python-amqplib
-	ec=$?
-	set -e
-	if [ $ec -ne 0 ]; then
-	    easy_install amqplib
-	fi
+    sudo apt-get install -qqy python-pip python-amqplib
+    sudo /usr/bin/pip install pytest
+    sudo easy_install amqplib
 
 test: deps
 	PYTHONPATH=lib/ /usr/local/bin/py.test test/

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
 .PHONY: test
 
 deps:
-    sudo apt-get install -qqy python-pip python-amqplib
-    sudo /usr/bin/pip install pytest
-    sudo easy_install amqplib
+	sudo apt-get install -qqy python-pip python-amqplib
+	sudo /usr/bin/pip install pytest
+	sudo easy_install amqplib
+
 
 test: deps
 	PYTHONPATH=lib/ /usr/local/bin/py.test test/


### PR DESCRIPTION
- Create dependencies target in Makefile
- Test target depends on deps target
- Remove Travis before_script for test dependencies 
- Run make test before building container
