### PR TITLE
Make webapi default be chainsmaster instead of master

### DIFF
--- a/misc/webapi/index.js
+++ b/misc/webapi/index.js
@@ -2,7 +2,7 @@
 
 var host         = '0.0.0.0',
 	port         = 7890,
-    chainsMaster = 'master',
+    chainsMaster = 'chainsmaster',
 	enableDebug  = false,
 	enableNotice = false;
 


### PR DESCRIPTION
Make webapi use chainsmaster as master. We probalby want to revert everything to "master" laster. But it's the quickes way right now.
